### PR TITLE
Extend dummy data and configure app for CDSW

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # incentives_query
+
 Dashboard for fast querying of incentive payment data.
+
+## Running the app
+
+The environment variable `INCENTIVES_DEMO` must have a value (any) when running in development.
+
+The app is run using the CDSW script run button (>), then opened by selecting Dash from the context menu (grid of squares at the top right).

--- a/app.py
+++ b/app.py
@@ -1,3 +1,4 @@
+import os
 import dash
 import dash_table
 import dash_core_components as dcc
@@ -10,29 +11,26 @@ import pandas as pd
 from generate_dummy_tables import generate_demo_tables
 
 
-
 spark_session = SparkSession.builder.getOrCreate()
 
-generate_demo_tables(spark_session)
+if os.environ.get("INCENTIVES_DEMO") is not None:
+    generate_demo_tables(spark_session)
 
 ons_hh_id = spark_session.sql("SELECT DISTINCT ons_household_id FROM summary")
 summary_col_names = spark_session.sql("SHOW COLUMNS IN summary")
 
 
 def df_to_list(df: DataFrame):
-    # assume always 1 column
+    # Assumption: df always has 1 column
     return df.toPandas().iloc[:,0].to_list()
 
 def create_options(option_values: list, key_names: list):
-    
     return [{key: id for key in key_names} for id in option_values]
 
 ons_hh_id_list = df_to_list(ons_hh_id)
-
 hh_id_options = create_options(ons_hh_id_list, ["label", "value"])
 
 summary_col_names_list = df_to_list(summary_col_names)
-
 summary_col_options = create_options(summary_col_names_list, ["name", "id"])
 
 
@@ -53,36 +51,18 @@ app.layout = html.Div([
     )
 
 ])
-"""
-@app.callback(
-    Output(component_id='table', component_property='data'),
-    Input(component_id='selection', component_property='value')
-)
-def update_output_div(input_value):
-    if input_value is not None:
-        return df[df[selection_col].isin(input_value)].to_dict("records")
 
-"""
+# @app.callback(
+#     Output(component_id='table', component_property='data'),
+#     Input(component_id='selection', component_property='value')
+# )
+# def update_output_div(input_value):
+#     if input_value is not None:
+#         return df[df[selection_col].isin(input_value)].to_dict("records")
+
 
 if __name__ == '__main__':
-    app.run_server(debug=True)
-
-
-
-    """
-    spark_session = SparkSession.builder.getOrCreate()
-
-    generate_demo_tables(spark_session)
-
-    #spark_session.sql("SELECT * FROM summary").show()
-
-    ons_hh_id = spark_session.sql("SELECT DISTINCT ons_household_id FROM summary")
-
-    ons_hh_id_list = ons_hh_id.toPandas()["ons_household_id"].to_list()
-
-    hh_id_options = [{key: id for key in ["label", "value"]} for id in ons_hh_id_list]
-
-    summary_col_names = spark_session.sql("SHOW COLUMNS IN summary").show()
-
-    print(summary_col_names)
-    """
+    port = os.environ.get("CDSW_PUBLIC_PORT")
+    ip = os.environ.get("CDSW_IP_ADDRESS")
+    debug = True if os.environ.get("INCENTIVES_DEMO") is not None else False
+    app.run_server(port=port, host=ip, debug=debug, use_reloader=False)  # Reloaded causes multiple launches in CDSW

--- a/generate_dummy_tables.py
+++ b/generate_dummy_tables.py
@@ -8,67 +8,75 @@ import pandas as pd
 
 _ = Field('en-gb', seed=42)
 
-#$set INCENTIVES_CONFIG_PATH=./config.yaml
-with open(os.environ.get("INCENTIVES_CONFIG_PATH")) as f:
-    config = yaml.safe_load(f)
-
 def define_summary_schema():
     return lambda: {
-        'ons_household_id': _('random.custom_code', mask='COV ############', digit='#'),
-        'participant_id': _('random.custom_code', mask='DHR-############', digit='#'),
+        'ons_household_id': _('random.custom_code', mask='COV 0000000000##', digit='#'),
+        'participant_id': _('random.custom_code', mask='DHR-000000000###', digit='#'),
         'fullname': _('person.full_name'),
-        'due_now': _('random.randints', amount=1)[0]
+        'email': _('person.email', domains=['gsnail.ac.uk']),
+        'street': _('address.street_name'),
+        'city': _('address.city'),
+        'county': _('address.state'),
+        'postcode': _('address.postal_code'),
+        'earned': _('random.randints', amount=1)[0],
+        'p_paid': _('random.randints', amount=1)[0],
+        'e_paid': _('random.randints', amount=1)[0],
+        'due_now': _('random.randints', amount=1)[0],
     }
 
+def define_visits_schema():
+    return lambda: {
+        'ons_household_id': _('random.custom_code', mask='COV 00000000000#', digit='#'),
+        'participant_id': _('random.custom_code', mask='DHR-0000000000##', digit='#'),
+        'fullname': _('person.full_name'),
+        'visit_date': _('datetime.formatted_datetime', fmt="%Y-%m-%d", start=1800, end=1802),
+        'visit_type': _('choice', items=["First Visit", "Follow-up Visit"]),
+        'participant_visit_status': _('choice', items=["Completed", "Cancelled"])
+    }
+
+def define_e_cheques_schema():
+    return lambda: {
+        'ons_household_id': _('random.custom_code', mask='COV 00000000000#', digit='#'),
+        'participant_id': _('random.custom_code', mask='DHR-0000000000##', digit='#'),
+        'recipient_name': _('person.full_name'),
+        'cheque_number': _('random.custom_code', mask='########', digit='#'),
+        'value_issued': _('random.custom_code', mask='########', digit='#'),
+        'date_issued': _('datetime.formatted_datetime', fmt="%Y-%m-%d", start=1800, end=1802),
+    }
+
+def define_p_cheques_schema():
+    return lambda: {
+        'ons_household_id': _('random.custom_code', mask='COV 00000000000#', digit='#'),
+        'participant_id': _('random.custom_code', mask='DHR-0000000000##', digit='#'),
+        'recipient_name': _('person.full_name'),
+        'full_name': _('person.full_name'),
+        'order_no': _('random.custom_code', mask='########', digit='#'),
+        'date_issued': _('datetime.formatted_datetime', fmt="%Y-%m-%d", start=1800, end=1802),
+        'value': _('random.randints', amount=1)[0]
+    }
 
 def schema_to_dataframe(session: SparkSession, schema_definition: Callable, num_records: int):
-
+    """Get PySpark DataFrame from a mimesis schema."""
     schema = Schema(schema=schema_definition)
-
     data = schema.create(iterations=num_records)
-
     pd_df = pd.DataFrame(data)
-
     ps_df = session.createDataFrame(pd_df)
-
     return ps_df
 
 
-def write_to_temp(df: DataFrame, name: str):
-
+def generate_temp_table(session: SparkSession, schema_definition: Callable, name: str, num_records: int):
+    """Generate temporary table with specified name."""
+    df = schema_to_dataframe(session, schema_definition, num_records)
     df.createOrReplaceTempView(name)
-
-
-
-
-def generate_temp_table(session: SparkSession, schema_definition: Callable, name: str):
-
-    summary_df = schema_to_dataframe(session, schema_definition, 100)
-
-    write_to_temp(summary_df, name)
     
-
-
-
 def generate_demo_tables(session: SparkSession):
-
-    generate_temp_table(session, define_summary_schema(), "summary")
-
-    generate_temp_table(session, define_summary_schema(), "summary2")
-
+    generate_temp_table(session, define_summary_schema(), "summary", 100)
+    generate_temp_table(session, define_visits_schema(), "visits", 500)
+    generate_temp_table(session, define_e_cheques_schema(), "e_cheques", 500)
+    generate_temp_table(session, define_p_cheques_schema(), "p_cheques", 500)
 
 
 if __name__ == "__main__":
-    #print(generate_summary_table().create(iterations=4))
-
-    #$set PYSPARK_PYTHON=D:\Repositories\incentives-env\Scripts\python.exe
-
     spark_session = SparkSession.builder.getOrCreate()
-
-    summary_schema = define_summary_schema()
-
-    summary_df = schema_to_dataframe(spark_session, summary_schema, 5)
-
-    write_to_temp(summary_df, "summary")
-
+    generate_demo_tables(spark_session)
     spark_session.sql("SELECT * FROM summary").show()


### PR DESCRIPTION
Extends dummy data to cover all 4 tables.

App now runs on CDSW, and uses the dummy data when the `INCENTIVES_DEMO` environment variable is set to any value.